### PR TITLE
FEATURE: interactive dropdown to switch scatterplot colormap

### DIFF
--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -13,7 +13,7 @@ from bokeh.server.server import Server
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.plotting import figure
-from bokeh.layouts import widgetbox, layout
+from bokeh.layouts import widgetbox, layout, row
 from bokeh.models import (ColumnDataSource,
                           CustomJS,
                           CDSView,
@@ -40,6 +40,7 @@ def _available_color_columns(dataframe):
     available_color_columns = list(dataframe.columns)
     available_color_columns.remove('info')  # expect all values may be unique
     available_color_columns.remove('path')  # expect all values may be unique
+    available_color_columns.remove('url')  # expect all values may be unique
     return available_color_columns
 
 
@@ -351,10 +352,11 @@ def make_makedoc(filename, color_column=None):
 
         source.selected.on_change('indices', load_selected)
 
-        dropdown = Select(title="Option:", value="foo",
+        dropdown = Select(title="Color coding:", value=color_column,
                           options=_available_color_columns(dataframe))
         def dropdown_update(attr, old, new):
-            print(dropdown.value)
+            embed = embedding(source, glyph_size=10, color_column=dropdown.value)
+            page_content.children[0] = row([embed, image_plot])
         dropdown.on_change('value', dropdown_update)
 
         page_content = layout([

--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -361,8 +361,8 @@ def make_makedoc(filename, color_column=None):
 
         page_content = layout([
             [embed, image_plot],
-            controls,
             [widgetbox(dropdown)],
+            controls,
             [table]
             ], sizing_mode="scale_width")
         doc.title = 'Bokeh microscopium app'

--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -20,7 +20,8 @@ from bokeh.models import (ColumnDataSource,
                           BooleanFilter,
                           Legend,
                           LinearColorMapper,
-                          ColorBar)
+                          ColorBar,
+                          Select)
 from bokeh.models.widgets import Button, DataTable, TableColumn
 import bokeh.palettes
 
@@ -33,6 +34,13 @@ def dataframe_from_file(filename):
     valid_y = df.y.notna()
     df = df[valid_x & valid_y]
     return df
+
+
+def _available_color_columns(dataframe):
+    available_color_columns = list(dataframe.columns)
+    available_color_columns.remove('info')  # expect all values may be unique
+    available_color_columns.remove('path')  # expect all values may be unique
+    return available_color_columns
 
 
 def imread(path):
@@ -342,9 +350,17 @@ def make_makedoc(filename, color_column=None):
             update_table(new, dataframe, table)
 
         source.selected.on_change('indices', load_selected)
+
+        dropdown = Select(title="Option:", value="foo",
+                          options=_available_color_columns(dataframe))
+        def dropdown_update(attr, old, new):
+            print(dropdown.value)
+        dropdown.on_change('value', dropdown_update)
+
         page_content = layout([
             [embed, image_plot],
             controls,
+            [widgetbox(dropdown)],
             [table]
             ], sizing_mode="scale_width")
         doc.title = 'Bokeh microscopium app'

--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -183,7 +183,7 @@ def _plot_continuous_data(source, embed, color_column, glyph_size):
     color_bar = ColorBar(color_mapper=color_mapper,
                          label_standoff=5,
                          border_line_color=None,
-                         location=(0,0))
+                         location=(0, 0))
     embed.scatter(source=source, x='x', y='y', size=glyph_size,
                   color={'field': color_column,
                          'transform': color_mapper})
@@ -261,7 +261,8 @@ def selected_images():
                              tools=tools_sel,
                              active_drag='pan',
                              active_scroll='wheel_zoom')
-    selected_images.image_rgba('image', 'x', 'y', 'dx', 'dy', source=image_holder)
+    selected_images.image_rgba('image', 'x', 'y', 'dx', 'dy',
+                               source=image_holder)
     _remove_axes_spines(selected_images)
     return selected_images, image_holder
 
@@ -335,8 +336,10 @@ def make_makedoc(filename, color_column=None):
         source = ColumnDataSource(dataframe)
         embed = embedding(source, glyph_size=10, color_column=color_column)
         image_plot, image_holder = selected_images()
-        table = empty_table(dataframe)
+        dropdown = Select(title="Color coding:", value=color_column,
+                          options=_available_color_columns(dataframe))
         controls = [button_save_table(table), button_print_page()]
+        table = empty_table(dataframe)
 
         def load_selected(attr, old, new):
             """Update images and table to display selected data."""
@@ -350,13 +353,12 @@ def make_makedoc(filename, color_column=None):
                                           source=image_holder)
             update_table(new, dataframe, table)
 
-        source.selected.on_change('indices', load_selected)
-
-        dropdown = Select(title="Color coding:", value=color_column,
-                          options=_available_color_columns(dataframe))
         def dropdown_update(attr, old, new):
-            embed = embedding(source, glyph_size=10, color_column=dropdown.value)
+            embed = embedding(source, glyph_size=10,
+                              color_column=dropdown.value)
             page_content.children[0] = row([embed, image_plot])
+
+        source.selected.on_change('indices', load_selected)
         dropdown.on_change('value', dropdown_update)
 
         page_content = layout([


### PR DESCRIPTION
There is now an interactive dropdown menu below the image embedding scatterplot, so that users can switch interactively between columns controlling the colour of points on the plot.

This is more useable than having to re-launch the app on every change (which users can't do if it's running on a server).

Notes:

1. This does produce a python error whenever you update the plots, but since that error doesn't seem to negatively affect functionality I suggest we ignore it for now. It's possible some future version of bokeh will address this.
```
WARNING:bokeh.document.document:Cannot apply patch to c2c52ba1-6460-4fa1-9524-d0710dd20656 which is not in the document anymore
```

2. We are choosing to replace an entire row in the bokeh layout, since it's not possible to replace just a single plot (bokeh's `row` doesn't support item assignment).

Relevant issues:
https://github.com/microscopium/microscopium/issues/99
https://github.com/microscopium/microscopium/issues/110